### PR TITLE
[bser] added test+bench for enc/dec of single object

### DIFF
--- a/bser/decode.go
+++ b/bser/decode.go
@@ -119,7 +119,6 @@ func decodeObject(r io.Reader, dest reflect.Value) error {
 	if err != nil {
 		return err
 	}
-
 	switch k := dest.Kind(); k {
 	case reflect.Map:
 		if dest.Type().Key().Kind() != reflect.String {

--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -1,1 +1,96 @@
 package bser
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type decodeTest struct {
+	encoded      []byte
+	expectedData interface{}
+	expectErr    bool
+	doDecode     func(decoder *Decoder) (interface{}, error)
+}
+
+var decodeTests = map[string]decodeTest{
+	"single_object": {
+		encoded: []byte(
+			"\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
+		),
+		expectedData: person{Name: "fred", Age: 20},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := person{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+}
+
+func TestDecode(t *testing.T) {
+	for testName, testCase := range decodeTests {
+		t.Run(testName, func(t *testing.T) {
+			testDecode(t, testCase)
+		})
+	}
+}
+
+func testDecode(t *testing.T, testCase decodeTest) {
+	t.Helper()
+	var (
+		buf     = bytes.NewBuffer(testCase.encoded)
+		decoder = NewDecoder(buf)
+	)
+
+	dst, err := testCase.doDecode(decoder)
+	if testCase.expectErr && err != nil {
+		return
+	}
+	if testCase.expectErr && err == nil {
+		t.Fatal("unexpectedly no error")
+	}
+	if !testCase.expectErr && err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !reflect.DeepEqual(dst, testCase.expectedData) {
+		t.Fatalf("unexpected decoded dst:\n\nexpected = %#v\n\nactual = %#v", testCase.expectedData, dst)
+	}
+}
+
+type decodeBench struct {
+	encoded  []byte
+	doDecode func(decoder *Decoder) (interface{}, error)
+}
+
+var decodeBenches = map[string]decodeBench{
+	"single_object": {
+		encoded: []byte(
+			"\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
+		),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := person{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+}
+
+var benchDecErr error
+
+func BenchmarkDecode(b *testing.B) {
+	for benchName, benchCase := range decodeBenches {
+		var err error
+		b.Run(fmt.Sprintf("data=%s", benchName), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				var (
+					buf     = bytes.NewBuffer(benchCase.encoded)
+					decoder = NewDecoder(buf)
+				)
+				_, err = benchCase.doDecode(decoder)
+			}
+		})
+		benchDecErr = err
+	}
+}

--- a/bser/encode.go
+++ b/bser/encode.go
@@ -120,6 +120,7 @@ func encode(buf []byte, d interface{}) ([]byte, error) {
 				return nil, err
 			}
 			for i := 0; i < r.Len(); i++ {
+				// TODO: special behaviour for slice of templated objects: https://facebook.github.io/watchman/docs/bser.html#array-of-templated-objects
 				if b, err = encode(b, r.Index(i).Interface()); err != nil {
 					return nil, err
 				}
@@ -133,12 +134,13 @@ func encode(buf []byte, d interface{}) ([]byte, error) {
 			}
 
 			for i := 0; i < num; i++ {
-				f := r.Field(i)
-				b, err = encode(b, r.Type().Field(i).Name)
+				fieldName := r.Type().Field(i).Name
+				b, err = encode(b, fieldName)
 				if err != nil {
 					return nil, err
 				}
-				b, err = encode(b, f)
+				fv := r.Field(i)
+				b, err = encode(b, fv.Interface())
 				if err != nil {
 					return nil, err
 				}

--- a/bser/encode_test.go
+++ b/bser/encode_test.go
@@ -1,7 +1,84 @@
 package bser
 
-import "testing"
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+type person struct {
+	Name string
+	Age  int
+}
+
+type encodeTest struct {
+	data        interface{}
+	expectedEnc []byte
+	expectErr   bool
+}
+
+/*
+expected values generated using python client,
+just modifying headers since python implementation always uses int32 - https://github.com/facebook/watchman/blob/master/python/pywatchman/pybser.py#L70
+ex:
+>>> import pywatchman
+>>> obj = {"Name": "fred", "Age": 20}
+>>> s = pywatchman.bser.dumps(obj)
+>>> print(s)
+b'\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14'
+>>>
+*/
+
+var encodeTests = map[string]encodeTest{
+	"single_object": {
+		data: person{Name: "fred", Age: 20},
+		expectedEnc: []byte(
+			"\x00\x01\x03\x19\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
+		),
+	},
+}
 
 func TestEncode(t *testing.T) {
+	for testName, testCase := range encodeTests {
+		t.Run(testName, func(t *testing.T) {
+			testEncode(t, testCase)
+		})
+	}
+}
 
+func testEncode(t *testing.T, testCase encodeTest) {
+	t.Helper()
+
+	b, err := Marshal(testCase.data)
+	if testCase.expectErr && err != nil {
+		return
+	}
+	if testCase.expectErr && err == nil {
+		t.Fatal("unexpectedly no error")
+	}
+	if !testCase.expectErr && err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !bytes.Equal(testCase.expectedEnc, b) {
+		t.Fatalf("unexpected encoded data:\n\nexpected = %v\n\nactual = %v", testCase.expectedEnc, b)
+	}
+}
+
+var encoderBenches = map[string]interface{}{
+	"single_2_field_object": person{Name: "fred", Age: 20},
+}
+
+var benchEncErr error
+
+func BenchmarkEncoder(b *testing.B) {
+	for benchName, data := range encoderBenches {
+		var err error
+		b.Run(fmt.Sprintf("data=%s", benchName), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err = Marshal(data)
+			}
+		})
+		benchEncErr = err
+	}
 }


### PR DESCRIPTION
Fixed an issue where objects would continually try to decode themselves causing an overflow issue. Also make size header int32 to be consistent with other implementation and added tests+benchmarks for encoding and decoding a simple 2 element object.

On my machine:

```
$ go test ./bser -run ! -bench . -race
goos: darwin
goarch: amd64
pkg: github.com/jonasi/watchman/bser
BenchmarkDecode/data=single_object-4              107174             10206 ns/op
BenchmarkEncoder/data=single_2_field_object-4             180253              6658 ns/op
PASS
ok      github.com/jonasi/watchman/bser 9.117s
```