### PR TITLE
add Marshaler and Unmarshaler interfaces

### DIFF
--- a/bser/encode.go
+++ b/bser/encode.go
@@ -8,14 +8,19 @@ import (
 	"reflect"
 )
 
-// Marshal returns the BSER encoding of d
-func Marshal(d interface{}) ([]byte, error) {
+// MarshalPDU returns the BSER encoding of d
+func MarshalPDU(d interface{}) ([]byte, error) {
 	var b bytes.Buffer
 	if err := NewEncoder(&b).Encode(d); err != nil {
 		return nil, err
 	}
 
 	return b.Bytes(), nil
+}
+
+// MarshalValue returns the BSER encoding of d
+func MarshalValue(d interface{}) ([]byte, error) {
+	return encode(nil, d)
 }
 
 // NewEncoder returns an initialized Encoder

--- a/bser/encode_test.go
+++ b/bser/encode_test.go
@@ -49,7 +49,7 @@ func TestEncode(t *testing.T) {
 func testEncode(t *testing.T, testCase encodeTest) {
 	t.Helper()
 
-	b, err := Marshal(testCase.data)
+	b, err := MarshalPDU(testCase.data)
 	if testCase.expectErr && err != nil {
 		return
 	}
@@ -76,7 +76,7 @@ func BenchmarkEncoder(b *testing.B) {
 		var err error
 		b.Run(fmt.Sprintf("data=%s", benchName), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err = Marshal(data)
+				_, err = MarshalPDU(data)
 			}
 		})
 		benchEncErr = err


### PR DESCRIPTION
for custom Marshal and Unmarshal functionality. Right now, the only
use for this is the RawMessage type. The Marshal functionality is not
yet implemented...

Unmarshal functionality is implemented by passing along a *[]byte
through all the decode calls.  probably can be optimized by passing
around offsets instead of constructing a new byte array.