### PR TITLE
[bser] add tests for slice data + fix int issue

### DIFF
--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -26,6 +26,116 @@ var decodeTests = map[string]decodeTest{
 			return dst, err
 		},
 	},
+	"string_slice": {
+		encoded: []byte(
+			"\x00\x01\x03\x1b\x00\x03\x06\x02\x03\x01a\x02\x03\x01b\x02\x03\x01c\x02\x03\x01d\x02\x03\x01e\x02\x03\x01f",
+		),
+		expectedData: []string{"a", "b", "c", "d", "e", "f"},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []string{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"pos_int8_slice": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+		expectedData: []int8{1, 2, 3, 4, 5, 6},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int8{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"neg_int8_slice": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\xff\x03\xfe\x03\xfd\x03\xfc\x03\xfb\x03\xfa",
+		),
+		expectedData: []int8{-1, -2, -3, -4, -5, -6},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int8{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"pos_int16_slice": {
+		encoded: []byte(
+			"\x00\x01\x03\x15\x00\x03\x06\x04\xe9\x03\x04\xea\x03\x04\xeb\x03\x04\xec\x03\x04\xed\x03\x04\xee\x03",
+		),
+		expectedData: []int16{1001, 1002, 1003, 1004, 1005, 1006},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int16{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"neg_int16_slice": {
+		encoded: []byte(
+			"\x00\x01\x03\x15\x00\x03\x06\x04\x17\xfc\x04\x16\xfc\x04\x15\xfc\x04\x14\xfc\x04\x13\xfc\x04\x12\xfc",
+		),
+		expectedData: []int16{-1001, -1002, -1003, -1004, -1005, -1006},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int16{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"pos_int32_slice": {
+		encoded: []byte(
+			"\x00\x01\x03!\x00\x03\x06\x05\xa1\x86\x01\x00\x05\xa2\x86\x01\x00\x05\xa3\x86\x01\x00\x05\xa4\x86\x01\x00\x05\xa5\x86\x01\x00\x05\xa6\x86\x01\x00",
+		),
+		expectedData: []int32{100001, 100002, 100003, 100004, 100005, 100006},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int32{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"neg_int32_slice": {
+		encoded: []byte(
+			"\x00\x01\x03!\x00\x03\x06\x05_y\xfe\xff\x05^y\xfe\xff\x05]y\xfe\xff\x05\\y\xfe\xff\x05[y\xfe\xff\x05Zy\xfe\xff",
+		),
+		expectedData: []int32{-100001, -100002, -100003, -100004, -100005, -100006},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int32{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"pos_int64_slice": {
+		encoded: []byte(
+			"\x00\x01\x039\x00\x03\x06\x06\x00^\xd0\xb2\x00\x00\x00\x00\x06\x01^\xd0\xb2\x00\x00\x00\x00\x06\x02^\xd0\xb2\x00\x00\x00\x00\x06\x03^\xd0\xb2\x00\x00\x00\x00\x06\x04^\xd0\xb2\x00\x00\x00\x00\x06\x05^\xd0\xb2\x00\x00\x00\x00",
+		),
+		expectedData: []int64{3_000_000_000, 3_000_000_001, 3_000_000_002, 3_000_000_003, 3_000_000_004, 3_000_000_005},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int64{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"neg_int64_slice": {
+		encoded: []byte(
+			"\x00\x01\x039\x00\x03\x06\x06\x00\xa2/M\xff\xff\xff\xff\x06\xff\xa1/M\xff\xff\xff\xff\x06\xfe\xa1/M\xff\xff\xff\xff\x06\xfd\xa1/M\xff\xff\xff\xff\x06\xfc\xa1/M\xff\xff\xff\xff\x06\xfb\xa1/M\xff\xff\xff\xff",
+		),
+		expectedData: []int64{-3_000_000_000, -3_000_000_001, -3_000_000_002, -3_000_000_003, -3_000_000_004, -3_000_000_005},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int64{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"float64_slice": {
+		encoded: []byte(
+			"\x00\x01\x039\x00\x03\x06\x07{\x14\xaeG\xe1z\x84?\x07{\x14\xaeG\xe1z\x94?\x07\xb8\x1e\x85\xebQ\xb8\x9e?\x07{\x14\xaeG\xe1z\xa4?\x07\x9a\x99\x99\x99\x99\x99\xa9?\x07\xb8\x1e\x85\xebQ\xb8\xae?",
+		),
+		expectedData: []float64{0.01, 0.02, 0.03, 0.04, 0.05, 0.06},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []float64{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
 }
 
 func TestDecode(t *testing.T) {
@@ -71,6 +181,66 @@ var decodeBenches = map[string]decodeBench{
 		),
 		doDecode: func(decoder *Decoder) (interface{}, error) {
 			dst := person{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"string_slice": {
+		encoded: []byte(
+			"\x00\x01\x03\x1b\x00\x03\x06\x02\x03\x01a\x02\x03\x01b\x02\x03\x01c\x02\x03\x01d\x02\x03\x01e\x02\x03\x01f",
+		),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []string{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"pos_int8_slice": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int8{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"pos_int16_slice": {
+		encoded: []byte(
+			"\x00\x01\x03\x15\x00\x03\x06\x04\xe9\x03\x04\xea\x03\x04\xeb\x03\x04\xec\x03\x04\xed\x03\x04\xee\x03",
+		),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int16{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"pos_int32_slice": {
+		encoded: []byte(
+			"\x00\x01\x03!\x00\x03\x06\x05\xa1\x86\x01\x00\x05\xa2\x86\x01\x00\x05\xa3\x86\x01\x00\x05\xa4\x86\x01\x00\x05\xa5\x86\x01\x00\x05\xa6\x86\x01\x00",
+		),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int32{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"pos_int64_slice": {
+		encoded: []byte(
+			"\x00\x01\x039\x00\x03\x06\x06\x00^\xd0\xb2\x00\x00\x00\x00\x06\x01^\xd0\xb2\x00\x00\x00\x00\x06\x02^\xd0\xb2\x00\x00\x00\x00\x06\x03^\xd0\xb2\x00\x00\x00\x00\x06\x04^\xd0\xb2\x00\x00\x00\x00\x06\x05^\xd0\xb2\x00\x00\x00\x00",
+		),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int64{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"float64_slice": {
+		encoded: []byte(
+			"\x00\x01\x039\x00\x03\x06\x07{\x14\xaeG\xe1z\x84?\x07{\x14\xaeG\xe1z\x94?\x07\xb8\x1e\x85\xebQ\xb8\x9e?\x07{\x14\xaeG\xe1z\xa4?\x07\x9a\x99\x99\x99\x99\x99\xa9?\x07\xb8\x1e\x85\xebQ\xb8\xae?",
+		),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []float64{}
 			err := decoder.Decode(&dst)
 			return dst, err
 		},

--- a/bser/encode.go
+++ b/bser/encode.go
@@ -187,11 +187,11 @@ func isNillable(k reflect.Kind) bool {
 
 func fitInt(v int) interface{} {
 	switch {
-	case v < math.MaxInt8:
+	case v < math.MaxInt8 && v > math.MinInt8:
 		return int8(v)
-	case v < math.MaxInt16:
+	case v < math.MaxInt16 && v > math.MinInt16:
 		return int16(v)
-	case v < math.MaxInt32:
+	case v < math.MaxInt32 && v > math.MinInt32:
 		return int32(v)
 	default:
 		return int64(v)

--- a/bser/encode_test.go
+++ b/bser/encode_test.go
@@ -3,6 +3,8 @@ package bser
 import (
 	"bytes"
 	"fmt"
+	"math"
+	"strconv"
 	"testing"
 )
 
@@ -34,6 +36,66 @@ var encodeTests = map[string]encodeTest{
 		data: person{Name: "fred", Age: 20},
 		expectedEnc: []byte(
 			"\x00\x01\x03\x19\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
+		),
+	},
+	"string_slice": {
+		data: []string{"a", "b", "c", "d", "e", "f"},
+		expectedEnc: []byte(
+			"\x00\x01\x03\x1b\x00\x03\x06\x02\x03\x01a\x02\x03\x01b\x02\x03\x01c\x02\x03\x01d\x02\x03\x01e\x02\x03\x01f",
+		),
+	},
+	"pos_int8_slice": {
+		data: []int{1, 2, 3, 4, 5, 6},
+		expectedEnc: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+	},
+	"neg_int8_slice": {
+		data: []int{-1, -2, -3, -4, -5, -6},
+		expectedEnc: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\xff\x03\xfe\x03\xfd\x03\xfc\x03\xfb\x03\xfa",
+		),
+	},
+	"pos_int16_slice": {
+		data: []int{1001, 1002, 1003, 1004, 1005, 1006},
+		expectedEnc: []byte(
+			"\x00\x01\x03\x15\x00\x03\x06\x04\xe9\x03\x04\xea\x03\x04\xeb\x03\x04\xec\x03\x04\xed\x03\x04\xee\x03",
+		),
+	},
+	"neg_int16_slice": {
+		data: []int{-1001, -1002, -1003, -1004, -1005, -1006},
+		expectedEnc: []byte(
+			"\x00\x01\x03\x15\x00\x03\x06\x04\x17\xfc\x04\x16\xfc\x04\x15\xfc\x04\x14\xfc\x04\x13\xfc\x04\x12\xfc",
+		),
+	},
+	"pos_int32_slice": {
+		data: []int{100001, 100002, 100003, 100004, 100005, 100006},
+		expectedEnc: []byte(
+			"\x00\x01\x03!\x00\x03\x06\x05\xa1\x86\x01\x00\x05\xa2\x86\x01\x00\x05\xa3\x86\x01\x00\x05\xa4\x86\x01\x00\x05\xa5\x86\x01\x00\x05\xa6\x86\x01\x00",
+		),
+	},
+	"neg_int32_slice": {
+		data: []int{-100001, -100002, -100003, -100004, -100005, -100006},
+		expectedEnc: []byte(
+			"\x00\x01\x03!\x00\x03\x06\x05_y\xfe\xff\x05^y\xfe\xff\x05]y\xfe\xff\x05\\y\xfe\xff\x05[y\xfe\xff\x05Zy\xfe\xff",
+		),
+	},
+	"pos_int64_slice": {
+		data: []int{3_000_000_000, 3_000_000_001, 3_000_000_002, 3_000_000_003, 3_000_000_004, 3_000_000_005},
+		expectedEnc: []byte(
+			"\x00\x01\x039\x00\x03\x06\x06\x00^\xd0\xb2\x00\x00\x00\x00\x06\x01^\xd0\xb2\x00\x00\x00\x00\x06\x02^\xd0\xb2\x00\x00\x00\x00\x06\x03^\xd0\xb2\x00\x00\x00\x00\x06\x04^\xd0\xb2\x00\x00\x00\x00\x06\x05^\xd0\xb2\x00\x00\x00\x00",
+		),
+	},
+	"neg_int64_slice": {
+		data: []int{-3_000_000_000, -3_000_000_001, -3_000_000_002, -3_000_000_003, -3_000_000_004, -3_000_000_005},
+		expectedEnc: []byte(
+			"\x00\x01\x039\x00\x03\x06\x06\x00\xa2/M\xff\xff\xff\xff\x06\xff\xa1/M\xff\xff\xff\xff\x06\xfe\xa1/M\xff\xff\xff\xff\x06\xfd\xa1/M\xff\xff\xff\xff\x06\xfc\xa1/M\xff\xff\xff\xff\x06\xfb\xa1/M\xff\xff\xff\xff",
+		),
+	},
+	"float64_slice": {
+		data: []float64{0.01, 0.02, 0.03, 0.04, 0.05, 0.06},
+		expectedEnc: []byte(
+			"\x00\x01\x039\x00\x03\x06\x07{\x14\xaeG\xe1z\x84?\x07{\x14\xaeG\xe1z\x94?\x07\xb8\x1e\x85\xebQ\xb8\x9e?\x07{\x14\xaeG\xe1z\xa4?\x07\x9a\x99\x99\x99\x99\x99\xa9?\x07\xb8\x1e\x85\xebQ\xb8\xae?",
 		),
 	},
 }
@@ -80,5 +142,72 @@ func BenchmarkEncoder(b *testing.B) {
 			}
 		})
 		benchEncErr = err
+	}
+}
+
+var encodeSliceBenches = map[string]func(numElems int) interface{}{
+	"string": func(numElems int) interface{} {
+		data := make([]string, numElems)
+		for i := 0; i < numElems; i++ {
+			data[i] = strconv.Itoa(i)
+		}
+		return data
+	},
+	"int8": func(numElems int) interface{} {
+		data := make([]int8, numElems)
+		for i := 0; i < numElems; i++ {
+			data[i] = int8(i)
+		}
+		return data
+	},
+	"int16": func(numElems int) interface{} {
+		data := make([]int16, numElems)
+		for i := 0; i < numElems; i++ {
+			data[i] = int16(math.MaxInt8 + i)
+		}
+		return data
+	},
+	"int32": func(numElems int) interface{} {
+		data := make([]int32, numElems)
+		for i := 0; i < numElems; i++ {
+			data[i] = int32(math.MaxInt16 + i)
+		}
+		return data
+	},
+	"int64": func(numElems int) interface{} {
+		data := make([]int64, numElems)
+		for i := 0; i < numElems; i++ {
+			data[i] = int64(math.MaxInt32 + i)
+		}
+		return data
+	},
+	"float64": func(numElems int) interface{} {
+		data := make([]float64, numElems)
+		for i := 0; i < numElems; i++ {
+			data[i] = float64(i)
+		}
+		return data
+	},
+}
+
+var benchEncSliceErr error
+
+func BenchmarkEncodeSlice(b *testing.B) {
+	allNumElems := []int{1, 3, 5, 10, 20, 50, 100}
+	for dtype, dataFn := range encodeSliceBenches {
+		b.Run(fmt.Sprintf("dtype=%s", dtype), func(b *testing.B) {
+			for _, numElems := range allNumElems {
+				var err error
+				b.Run(fmt.Sprintf("num_elems=%d", numElems), func(b *testing.B) {
+					b.StopTimer()
+					data := dataFn(numElems)
+					b.StartTimer()
+					for i := 0; i < b.N; i++ {
+						_, err = MarshalPDU(data)
+					}
+				})
+				benchEncSliceErr = err
+			}
+		})
 	}
 }


### PR DESCRIPTION
Added some tests and benchmarks for encoding/decoding slice data. Also fixed an issue where negative values weren't being considered when determining the minimum number of bits needed to represent an integer value.

Plotting the results of `BenchmarkEncodeSlice` shows that both time and memory allocations seem to increase linearly with number of elements in the slice which seems expected.  The "string" case is higher than the others, so it might be worth looking in to reducing how often we call `append()` in that case.

![time-v-num_elems](https://user-images.githubusercontent.com/33360408/74194653-4dbab400-4c1f-11ea-9bff-8b542b3d1727.png)

![allocs-v-num_elems](https://user-images.githubusercontent.com/33360408/74194671-54e1c200-4c1f-11ea-8fc1-92a2fc5912d9.png)
