### PR TITLE
[bser] handle arrays along w/ slices

### DIFF
--- a/bser/decode.go
+++ b/bser/decode.go
@@ -140,8 +140,8 @@ func decodeArray(r io.Reader, dest reflect.Value, buf *[]byte) error {
 		return err
 	}
 
-	if dest != emptyValue && dest.Kind() != reflect.Slice {
-		return fmt.Errorf("Expected slice, found %s", dest.Kind())
+	if dest != emptyValue && dest.Kind() != reflect.Slice && dest.Kind() != reflect.Array {
+		return fmt.Errorf("Expected slice or array, found %s", dest.Kind())
 	}
 
 	var length int
@@ -149,11 +149,14 @@ func decodeArray(r io.Reader, dest reflect.Value, buf *[]byte) error {
 		return err
 	}
 
-	if dest != emptyValue {
+	if dest != emptyValue && dest.Kind() == reflect.Slice {
 		dest.Set(reflect.MakeSlice(dest.Type(), length, length))
 	}
 
 	for i := 0; i < length; i++ {
+		if i >= dest.Len() {
+			continue
+		}
 		v := emptyValue
 		if dest != emptyValue {
 			v = reflect.New(dest.Type().Elem())

--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -26,6 +26,39 @@ var decodeTests = map[string]decodeTest{
 			return dst, err
 		},
 	},
+	"pos_int8_array": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+		expectedData: [6]int8{1, 2, 3, 4, 5, 6},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst [6]int8
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int8_array_insufficient_size": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+		expectedData: [3]int8{1, 2, 3},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst [3]int8
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int8_array_greater_size": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+		expectedData: [8]int8{1, 2, 3, 4, 5, 6, 0, 0},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst [8]int8
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
 	"string_slice": {
 		encoded: []byte(
 			"\x00\x01\x03\x1b\x00\x03\x06\x02\x03\x01a\x02\x03\x01b\x02\x03\x01c\x02\x03\x01d\x02\x03\x01e\x02\x03\x01f",

--- a/bser/encode.go
+++ b/bser/encode.go
@@ -119,7 +119,7 @@ func encode(buf []byte, d interface{}) ([]byte, error) {
 			b := make([]byte, 8)
 			order.PutUint64(b, math.Float64bits(r.Float()))
 			return appendItem(buf, 0x07, b), nil
-		case reflect.Slice:
+		case reflect.Slice, reflect.Array:
 			b, err := encode(nil, r.Len())
 			if err != nil {
 				return nil, err

--- a/bser/encode_test.go
+++ b/bser/encode_test.go
@@ -38,6 +38,12 @@ var encodeTests = map[string]encodeTest{
 			"\x00\x01\x03\x19\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
 		),
 	},
+	"pos_int8_array": {
+		data: [6]int{1, 2, 3, 4, 5, 6},
+		expectedEnc: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+	},
 	"string_slice": {
 		data: []string{"a", "b", "c", "d", "e", "f"},
 		expectedEnc: []byte(


### PR DESCRIPTION
Since it looks like `json` pkg is [able to encode/decode from/to an array](https://play.golang.org/p/v8wmljd9f2q) we should too. 