### PR TITLE
[bser] add tests for enc/dec invalid types

### DIFF
--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -187,6 +187,94 @@ var decodeTests = map[string]decodeTest{
 			return dst, err
 		},
 	},
+	"invalid_size_type_identifier": {
+		encoded: []byte(
+			"\x00\x01\xff\x02\x03\x10", // encoded 16 with int8 type in header replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int8
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"invalid_type_identifier": {
+		encoded: []byte(
+			"\x00\x01\x03\x02\xff\x10", // encoded 16 with int8 type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int8
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"slice_of_invalid_type": {
+		encoded: []byte(
+			"\x00\x01\x03\x07\x00\x03\x02\xff\x01\xff\x02", // encoded [1, 2] with int8 type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst = []int8{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"slice_with_invalid_length_type": {
+		encoded: []byte(
+			"\x00\x01\x03\x07\x00\xff\x02\x03\x01\x03\x02", // encoded [1, 2] with int8 length type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst = []int8{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"object_with_invalid_key_type": {
+		encoded: []byte(
+			"\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\xff\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := person{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"object_with_invalid_value_type": {
+		encoded: []byte(
+			"\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\xff\x14",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := person{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"map_with_invalid_key_type": {
+		encoded: []byte(
+			"\x00\x01\x03\x08\x01\x03\x01\xff\x03\x01a\x03\x01", // encoded {"a": 1} with string type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[string]int{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"map_with_invalid_value_type": {
+		encoded: []byte(
+			"\x00\x01\x03\x08\x01\x03\x01\x02\x03\x01a\xff\x01", // encoded {"a": 1} with int8 type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[string]int{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
 }
 
 func TestDecode(t *testing.T) {

--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -169,6 +169,24 @@ var decodeTests = map[string]decodeTest{
 			return dst, err
 		},
 	},
+	"map_str_bool": {
+		encoded: []byte(
+			"\x00\x01\x05!\x00\x00\x00\x01\x03\x06\x02\x03\x01a\x08\x02\x03\x01b\t\x02\x03\x01c\x08\x02\x03\x01d\t\x02\x03\x01e\x08\x02\x03\x01f\t",
+		),
+		expectedData: map[string]bool{
+			"a": true,
+			"b": false,
+			"c": true,
+			"d": false,
+			"e": true,
+			"f": false,
+		},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[string]bool{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
 }
 
 func TestDecode(t *testing.T) {
@@ -274,6 +292,16 @@ var decodeBenches = map[string]decodeBench{
 		),
 		doDecode: func(decoder *Decoder) (interface{}, error) {
 			dst := []float64{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"map_str_bool": {
+		encoded: []byte(
+			"\x00\x01\x05!\x00\x00\x00\x01\x03\x06\x02\x03\x01a\x08\x02\x03\x01b\t\x02\x03\x01c\x08\x02\x03\x01d\t\x02\x03\x01e\x08\x02\x03\x01f\t",
+		),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[string]bool{}
 			err := decoder.Decode(&dst)
 			return dst, err
 		},

--- a/bser/encode_test.go
+++ b/bser/encode_test.go
@@ -13,6 +13,10 @@ type person struct {
 	Age  int
 }
 
+type unencodable struct {
+	C chan string
+}
+
 type encodeTest struct {
 	data        interface{}
 	expectedEnc []byte
@@ -121,6 +125,32 @@ var encodeTests = map[string]encodeTest{
 		expectedEnc: []byte(
 			"\x00\x01\x03\x08\x01\x03\x01\x02\x03\x01a\x09",
 		),
+	},
+	"map_str_chan": {
+		data: map[string]chan string{
+			"a": make(chan string),
+			"b": make(chan string),
+		},
+		expectErr: true,
+	},
+	"chan_slice": {
+		data: []chan string{
+			make(chan string),
+			make(chan string),
+		},
+		expectErr: true,
+	},
+	"object_with_chan_field": {
+		data: unencodable{
+			C: make(chan string),
+		},
+		expectErr: true,
+	},
+	"func": {
+		data: func() int {
+			return 0
+		},
+		expectErr: true,
 	},
 }
 


### PR DESCRIPTION
Depends on #10 

Added some tests to verify an error is returned when trying to encode a value of an un-encodable type or when trying to decode a value with an invalid type identifier. 