### PR TITLE
[bser] add tests for decoding to invalid dst

### DIFF
--- a/bser/bser.go
+++ b/bser/bser.go
@@ -11,10 +11,12 @@ var (
 	protocolPrefix  = []byte{0, 1}
 	order           = binary.LittleEndian
 	typString       = reflect.TypeOf("")
+	typInt          = reflect.TypeOf(int(0))
 	typInt8         = reflect.TypeOf(int8(0))
 	typInt16        = reflect.TypeOf(int16(0))
 	typInt32        = reflect.TypeOf(int32(0))
 	typInt64        = reflect.TypeOf(int64(0))
+	typFloat32      = reflect.TypeOf(float32(0))
 	typFloat64      = reflect.TypeOf(float64(0))
 	typGenericSlice = reflect.TypeOf([]interface{}{})
 	typGenericMap   = reflect.TypeOf(map[string]interface{}{})

--- a/bser/decode.go
+++ b/bser/decode.go
@@ -265,6 +265,9 @@ func decodeString(r io.Reader, dest reflect.Value, buf *[]byte) error {
 	}
 
 	if dest != emptyValue {
+		if !canSetString(dest) {
+			return fmt.Errorf("can't decode string to %s", dest.Kind())
+		}
 		dest.SetString(string(b))
 	}
 	if buf != nil {
@@ -285,6 +288,9 @@ func decodeInt8(r io.Reader, dest reflect.Value, buf *[]byte) error {
 	}
 
 	if dest != emptyValue {
+		if !canSetInt(dest) {
+			return fmt.Errorf("can't decode int8 to %s", dest.Kind())
+		}
 		dest.SetInt(int64(b[0]))
 	}
 	if buf != nil {
@@ -305,6 +311,9 @@ func decodeInt16(r io.Reader, dest reflect.Value, buf *[]byte) error {
 	}
 
 	if dest != emptyValue {
+		if !canSetInt(dest) {
+			return fmt.Errorf("can't decode int16 to %s", dest.Kind())
+		}
 		v := order.Uint16(b)
 		dest.SetInt(int64(v))
 	}
@@ -326,6 +335,9 @@ func decodeInt32(r io.Reader, dest reflect.Value, buf *[]byte) error {
 	}
 
 	if dest != emptyValue {
+		if !canSetInt(dest) {
+			return fmt.Errorf("can't decode int32 to %s", dest.Kind())
+		}
 		v := order.Uint32(b)
 		dest.SetInt(int64(v))
 	}
@@ -347,6 +359,9 @@ func decodeInt64(r io.Reader, dest reflect.Value, buf *[]byte) error {
 	}
 
 	if dest != emptyValue {
+		if !canSetInt(dest) {
+			return fmt.Errorf("can't decode int64 to %s", dest.Kind())
+		}
 		v := order.Uint64(b)
 		dest.SetInt(int64(v))
 	}
@@ -368,6 +383,9 @@ func decodeReal(r io.Reader, dest reflect.Value, buf *[]byte) error {
 	}
 
 	if dest != emptyValue {
+		if !canSetFloat(dest) {
+			return fmt.Errorf("can't decode real to %s", dest.Kind())
+		}
 		v := order.Uint64(b)
 		dest.SetFloat(math.Float64frombits(v))
 	}
@@ -384,6 +402,9 @@ func decodeBool(v bool, dest reflect.Value) error {
 		return err
 	}
 
+	if !canSetBool(dest) {
+		return fmt.Errorf("can't decode bool to %s", dest.Kind())
+	}
 	dest.SetBool(v)
 	return nil
 }
@@ -482,4 +503,26 @@ func prep(v reflect.Value, typ reflect.Type) (reflect.Value, error) {
 	}
 
 	return reflect.Value{}, fmt.Errorf("Interface found, but expected %s", typ)
+}
+
+// canSetString checks if we can call SetString() on v - https://golang.org/pkg/reflect/#Value.SetString
+func canSetString(v reflect.Value) bool {
+	return v.CanSet() && v.Type() == typString
+}
+
+// canSetInt checks if we can call SetInt() on v - https://golang.org/pkg/reflect/#Value.SetInt
+func canSetInt(v reflect.Value) bool {
+	validType := v.Type() == typInt || v.Type() == typInt8 || v.Type() == typInt16 || v.Type() == typInt32 || v.Type() == typInt64
+	return v.CanSet() && validType
+}
+
+// canSetFloat checks if we can call SetFloat() on v - https://golang.org/pkg/reflect/#Value.SetFloat
+func canSetFloat(v reflect.Value) bool {
+	validType := v.Type() == typFloat32 || v.Type() == typFloat64
+	return v.CanSet() && validType
+}
+
+// canSetBool checks if we can call SetBool() on v - https://golang.org/pkg/reflect/#Value.SetBool
+func canSetBool(v reflect.Value) bool {
+	return v.CanSet() && v.Type() == typBool
 }

--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -187,6 +187,94 @@ var decodeTests = map[string]decodeTest{
 			return dst, err
 		},
 	},
+	"invalid_size_type_identifier": {
+		encoded: []byte(
+			"\x00\x01\xff\x02\x03\x10", // encoded 16 with int8 type in header replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int8
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"invalid_type_identifier": {
+		encoded: []byte(
+			"\x00\x01\x03\x02\xff\x10", // encoded 16 with int8 type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int8
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"slice_of_invalid_type": {
+		encoded: []byte(
+			"\x00\x01\x03\x07\x00\x03\x02\xff\x01\xff\x02", // encoded [1, 2] with int8 type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst = []int8{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"slice_with_invalid_length_type": {
+		encoded: []byte(
+			"\x00\x01\x03\x07\x00\xff\x02\x03\x01\x03\x02", // encoded [1, 2] with int8 length type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst = []int8{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"object_with_invalid_key_type": {
+		encoded: []byte(
+			"\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\xff\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := person{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"object_with_invalid_value_type": {
+		encoded: []byte(
+			"\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\xff\x14",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := person{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"map_with_invalid_key_type": {
+		encoded: []byte(
+			"\x00\x01\x03\x08\x01\x03\x01\xff\x03\x01a\x03\x01", // encoded {"a": 1} with string type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[string]int{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"map_with_invalid_value_type": {
+		encoded: []byte(
+			"\x00\x01\x03\x08\x01\x03\x01\x02\x03\x01a\xff\x01", // encoded {"a": 1} with int8 type replaced with 0xff
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[string]int{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
 }
 
 func TestDecode(t *testing.T) {

--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+type nonDecodable interface {
+	valid() bool
+}
+
 type decodeTest struct {
 	encoded      []byte
 	expectedData interface{}
@@ -271,6 +275,229 @@ var decodeTests = map[string]decodeTest{
 		expectErr: true,
 		doDecode: func(decoder *Decoder) (interface{}, error) {
 			dst := map[string]int{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"non_pointer_dst": {
+		encoded: []byte(
+			"\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := person{}
+			err := decoder.Decode(dst)
+			return dst, err
+		},
+	},
+	"int8_array_to_object": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := person{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int8_array_to_string_arr": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []string{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int8_array_to_interface": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst nonDecodable
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int8_array_to_interface_arr": {
+		encoded: []byte(
+			"\x00\x01\x03\x0f\x00\x03\x06\x03\x01\x03\x02\x03\x03\x03\x04\x03\x05\x03\x06",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst []nonDecodable
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int16_arr_to_string_arr": {
+		encoded: []byte(
+			"\x00\x01\x03\x15\x00\x03\x06\x04\xe9\x03\x04\xea\x03\x04\xeb\x03\x04\xec\x03\x04\xed\x03\x04\xee\x03",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []string{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int16_arr_to_interface_arr": {
+		encoded: []byte(
+			"\x00\x01\x03\x15\x00\x03\x06\x04\xe9\x03\x04\xea\x03\x04\xeb\x03\x04\xec\x03\x04\xed\x03\x04\xee\x03",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst []nonDecodable
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int32_arr_to_string_arr": {
+		encoded: []byte(
+			"\x00\x01\x03!\x00\x03\x06\x05\xa1\x86\x01\x00\x05\xa2\x86\x01\x00\x05\xa3\x86\x01\x00\x05\xa4\x86\x01\x00\x05\xa5\x86\x01\x00\x05\xa6\x86\x01\x00",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []string{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int32_arr_to_interface_arr": {
+		encoded: []byte(
+			"\x00\x01\x03!\x00\x03\x06\x05\xa1\x86\x01\x00\x05\xa2\x86\x01\x00\x05\xa3\x86\x01\x00\x05\xa4\x86\x01\x00\x05\xa5\x86\x01\x00\x05\xa6\x86\x01\x00",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst []nonDecodable
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int64_arr_to_string_arr": {
+		encoded: []byte(
+			"\x00\x01\x039\x00\x03\x06\x06\x00^\xd0\xb2\x00\x00\x00\x00\x06\x01^\xd0\xb2\x00\x00\x00\x00\x06\x02^\xd0\xb2\x00\x00\x00\x00\x06\x03^\xd0\xb2\x00\x00\x00\x00\x06\x04^\xd0\xb2\x00\x00\x00\x00\x06\x05^\xd0\xb2\x00\x00\x00\x00",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []string{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int64_arr_to_interface_arr": {
+		encoded: []byte(
+			"\x00\x01\x039\x00\x03\x06\x06\x00^\xd0\xb2\x00\x00\x00\x00\x06\x01^\xd0\xb2\x00\x00\x00\x00\x06\x02^\xd0\xb2\x00\x00\x00\x00\x06\x03^\xd0\xb2\x00\x00\x00\x00\x06\x04^\xd0\xb2\x00\x00\x00\x00\x06\x05^\xd0\xb2\x00\x00\x00\x00",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst []nonDecodable
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"object_to_int_slice": {
+		encoded: []byte(
+			"\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"string_slice_to_int_array": {
+		encoded: []byte(
+			"\x00\x01\x03\x1b\x00\x03\x06\x02\x03\x01a\x02\x03\x01b\x02\x03\x01c\x02\x03\x01d\x02\x03\x01e\x02\x03\x01f",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := []int{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"dst_map_has_int_keys": {
+		encoded: []byte(
+			"\x00\x01\x05\x0b\x00\x00\x00\x01\x03\x01\x02\x03\x011\x02\x03\x01a",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[int]string{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"map_to_interface": {
+		encoded: []byte(
+			"\x00\x01\x05\x0b\x00\x00\x00\x01\x03\x01\x02\x03\x011\x02\x03\x01a",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst nonDecodable
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"bool_to_interface": {
+		encoded: []byte(
+			"\x00\x01\x05\x01\x00\x00\x00\x08",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst nonDecodable
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"bool_to_int": {
+		encoded: []byte(
+			"\x00\x01\x05\x01\x00\x00\x00\x08",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"float_to_string": {
+		encoded: []byte(
+			"\x00\x01\x05\t\x00\x00\x00\x07\xaeG\xe1z\x14\xae\xf3?",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst string
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"dst_map_has_incorrect_field_type": {
+		encoded: []byte(
+			"\x00\x01\x05\x0b\x00\x00\x00\x01\x03\x01\x02\x03\x011\x02\x03\x01a",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[string]int{} // encoded data was of type map[string]string
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"dst_object_has_incorrect_field_type": {
+		encoded: []byte(
+			"\x00\x01\x05\x19\x00\x00\x00\x01\x03\x02\x02\x03\x04Name\x02\x03\x04fred\x02\x03\x03Age\x03\x14",
+		),
+		expectErr: true,
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := struct {
+				Name int // encoded object specifies this field should have string value
+				Age  int
+			}{}
 			err := decoder.Decode(&dst)
 			return dst, err
 		},

--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -169,6 +169,24 @@ var decodeTests = map[string]decodeTest{
 			return dst, err
 		},
 	},
+	"map_str_bool": {
+		encoded: []byte(
+			"\x00\x01\x05!\x00\x00\x00\x01\x03\x06\x02\x03\x01a\x08\x02\x03\x01b\t\x02\x03\x01c\x08\x02\x03\x01d\t\x02\x03\x01e\x08\x02\x03\x01f\t",
+		),
+		expectedData: map[string]bool{
+			"a": true,
+			"b": false,
+			"c": true,
+			"d": false,
+			"e": true,
+			"f": false,
+		},
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[string]bool{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
 }
 
 func TestDecode(t *testing.T) {
@@ -274,6 +292,16 @@ var decodeBenches = map[string]decodeBench{
 		),
 		doDecode: func(decoder *Decoder) (interface{}, error) {
 			dst := []float64{}
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"map_str_bool": {
+		encoded: []byte(
+			"\x00\x01\x05!\x00\x00\x00\x01\x03\x06\x02\x03\x01a\x08\x02\x03\x01b\t\x02\x03\x01c\x08\x02\x03\x01d\t\x02\x03\x01e\x08\x02\x03\x01f\t",
+		),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			dst := map[string]bool{}
 			err := decoder.Decode(&dst)
 			return dst, err
 		},

--- a/bser/encode_test.go
+++ b/bser/encode_test.go
@@ -13,6 +13,10 @@ type person struct {
 	Age  int
 }
 
+type unencodable struct {
+	C chan string
+}
+
 type encodeTest struct {
 	data        interface{}
 	expectedEnc []byte
@@ -121,6 +125,32 @@ var encodeTests = map[string]encodeTest{
 		expectedEnc: []byte(
 			"\x00\x01\x03\x08\x01\x03\x01\x02\x03\x01a\x09",
 		),
+	},
+	"map_str_chan": {
+		data: map[string]chan string{
+			"a": make(chan string),
+			"b": make(chan string),
+		},
+		expectErr: true,
+	},
+	"chan_slice": {
+		data: []chan string{
+			make(chan string),
+			make(chan string),
+		},
+		expectErr: true,
+	},
+	"object_with_chan_field": {
+		data: unencodable{
+			C: make(chan string),
+		},
+		expectErr: true,
+	},
+	"func": {
+		data: func() int {
+			return 0
+		},
+		expectErr: true,
 	},
 }
 


### PR DESCRIPTION
Depends on #10 and #11 

Added some tests for attempting to decode in to an incompatible destination. Also added a few checks prior to calling `dest.SetString()`, `dest.SetInt()`, `dest.SetFloat()`, and `dest.SetBool()` to prevent panics. We may want to adjust this logic to make conversions where it makes sense (e.g. use `strconv.Itoa()` if attempting to decode int value to string `dest`, convert int->float64, etc.). This may be overkill though since it [doesn't seem like the json decoder has such logic](https://play.golang.org/p/ZwbqeHHtTd8).

As a follow up we should probably start using a concrete error type (similar to the json [UnmarshalTypeError](https://golang.org/pkg/encoding/json/#UnmarshalTypeError)) instead of `fmt.Errorf()` to enforce consistent error messages and provide additional traceability.