### PR TITLE
[bser] handle type aliases when encoding/decoding

### DIFF
--- a/bser/decode.go
+++ b/bser/decode.go
@@ -510,22 +510,22 @@ func prep(v reflect.Value, typ reflect.Type) (reflect.Value, error) {
 
 // canSetString checks if we can call SetString() on v - https://golang.org/pkg/reflect/#Value.SetString
 func canSetString(v reflect.Value) bool {
-	return v.CanSet() && v.Type() == typString
+	return v.CanSet() && v.Kind() == reflect.String
 }
 
 // canSetInt checks if we can call SetInt() on v - https://golang.org/pkg/reflect/#Value.SetInt
 func canSetInt(v reflect.Value) bool {
-	validType := v.Type() == typInt || v.Type() == typInt8 || v.Type() == typInt16 || v.Type() == typInt32 || v.Type() == typInt64
+	validType := v.Kind() == reflect.Int || v.Kind() == reflect.Int8 || v.Kind() == reflect.Int16 || v.Kind() == reflect.Int32 || v.Kind() == reflect.Int64
 	return v.CanSet() && validType
 }
 
 // canSetFloat checks if we can call SetFloat() on v - https://golang.org/pkg/reflect/#Value.SetFloat
 func canSetFloat(v reflect.Value) bool {
-	validType := v.Type() == typFloat32 || v.Type() == typFloat64
+	validType := v.Kind() == reflect.Float32 || v.Kind() == reflect.Float64
 	return v.CanSet() && validType
 }
 
 // canSetBool checks if we can call SetBool() on v - https://golang.org/pkg/reflect/#Value.SetBool
 func canSetBool(v reflect.Value) bool {
-	return v.CanSet() && v.Type() == typBool
+	return v.CanSet() && v.Kind() == reflect.Bool
 }

--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -227,6 +227,83 @@ var decodeTests = map[string]decodeTest{
 			return dst, err
 		},
 	},
+	"string_alias": {
+		encoded: []byte(
+			"\x00\x01\x03\x08\x02\x03\x05hello",
+		),
+		expectedData: stringAlias("hello"),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst stringAlias
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int8_alias": {
+		encoded: []byte(
+			"\x00\x01\x03\x02\x03\x02",
+		),
+		expectedData: int8Alias(2),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int8Alias
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int16_alias": {
+		encoded: []byte(
+			"\x00\x01\x03\x03\x04\xe9\x03",
+		),
+		expectedData: int16Alias(1001),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int16Alias
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int32_alias": {
+		encoded: []byte(
+			"\x00\x01\x03\x05\x05\xa1\x86\x01\x00",
+		),
+		expectedData: int32Alias(100001),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int32Alias
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int64_alias": {
+		encoded: []byte(
+			"\x00\x01\x03\x09\x06\x01^\xd0\xb2\x00\x00\x00\x00",
+		),
+		expectedData: int64Alias(3_000_000_001),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int64Alias
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"int_alias_int32_value": {
+		encoded: []byte(
+			"\x00\x01\x03\x05\x05\xa1\x86\x01\x00",
+		),
+		expectedData: int64Alias(100001),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst int64Alias
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
+	"bool_alias": {
+		encoded: []byte(
+			"\x00\x01\x03\x01\x09",
+		),
+		expectedData: boolAlias(false),
+		doDecode: func(decoder *Decoder) (interface{}, error) {
+			var dst boolAlias
+			err := decoder.Decode(&dst)
+			return dst, err
+		},
+	},
 	"invalid_size_type_identifier": {
 		encoded: []byte(
 			"\x00\x01\xff\x02\x03\x10", // encoded 16 with int8 type in header replaced with 0xff

--- a/bser/encode.go
+++ b/bser/encode.go
@@ -111,6 +111,20 @@ func encode(buf []byte, d interface{}) ([]byte, error) {
 		}
 
 		switch r.Kind() {
+		case reflect.String:
+			return encode(buf, r.String())
+		case reflect.Int8:
+			return encode(buf, int8(r.Int()))
+		case reflect.Int16:
+			return encode(buf, int16(r.Int()))
+		case reflect.Int32:
+			return encode(buf, int32(r.Int()))
+		case reflect.Int64:
+			return encode(buf, r.Int())
+		case reflect.Int:
+			return encode(buf, int(r.Int()))
+		case reflect.Bool:
+			return encode(buf, r.Bool())
 		case reflect.Float32:
 			b := make([]byte, 8)
 			order.PutUint64(b, math.Float64bits(r.Float()))

--- a/bser/encode_test.go
+++ b/bser/encode_test.go
@@ -17,6 +17,14 @@ type unencodable struct {
 	C chan string
 }
 
+type stringAlias string
+type int8Alias int8
+type int16Alias int16
+type int32Alias int32
+type int64Alias int64
+type intAlias int
+type boolAlias bool
+
 type encodeTest struct {
 	data        interface{}
 	expectedEnc []byte
@@ -124,6 +132,48 @@ var encodeTests = map[string]encodeTest{
 		},
 		expectedEnc: []byte(
 			"\x00\x01\x03\x08\x01\x03\x01\x02\x03\x01a\x09",
+		),
+	},
+	"string_alias": {
+		data: stringAlias("hello"),
+		expectedEnc: []byte(
+			"\x00\x01\x03\x08\x02\x03\x05hello",
+		),
+	},
+	"int8_alias": {
+		data: int8Alias(2),
+		expectedEnc: []byte(
+			"\x00\x01\x03\x02\x03\x02",
+		),
+	},
+	"int16_alias": {
+		data: int16Alias(1001),
+		expectedEnc: []byte(
+			"\x00\x01\x03\x03\x04\xe9\x03",
+		),
+	},
+	"int32_alias": {
+		data: int32Alias(100001),
+		expectedEnc: []byte(
+			"\x00\x01\x03\x05\x05\xa1\x86\x01\x00",
+		),
+	},
+	"int64_alias": {
+		data: int64Alias(3_000_000_001),
+		expectedEnc: []byte(
+			"\x00\x01\x03\x09\x06\x01^\xd0\xb2\x00\x00\x00\x00",
+		),
+	},
+	"int_alias_int32_value": {
+		data: intAlias(100001),
+		expectedEnc: []byte(
+			"\x00\x01\x03\x05\x05\xa1\x86\x01\x00",
+		),
+	},
+	"bool_alias": {
+		data: boolAlias(false),
+		expectedEnc: []byte(
+			"\x00\x01\x03\x01\x09",
 		),
 	},
 	"map_str_chan": {


### PR DESCRIPTION
Previously when encoding we were only matching the builtin types which would lead to a confusing error (ex: "Unsupported type: string ") when attempting to encode a value of an alias type.

When decoding we were incorrectly checking `Type()` instead of `Kind()` when determining if we would call one of the `SetX()` methods (such as [SetString()](https://golang.org/pkg/reflect/#Value.SetString)) which lead to an even more confusing error: "can't decode string to string"