### PR TITLE
fix rawmessage decoding of slices

### DIFF
--- a/bser/decode.go
+++ b/bser/decode.go
@@ -143,11 +143,12 @@ func decodeArray(r io.Reader, dest reflect.Value, buf *[]byte) error {
 	}
 
 	for i := 0; i < length; i++ {
-		if i >= dest.Len() {
-			continue
-		}
-		v := emptyValue
-		if dest != emptyValue {
+		var (
+			noset = dest == emptyValue || i >= dest.Len()
+			v     = emptyValue
+		)
+
+		if !noset {
 			v = reflect.New(dest.Type().Elem())
 		}
 
@@ -155,7 +156,7 @@ func decodeArray(r io.Reader, dest reflect.Value, buf *[]byte) error {
 			return err
 		}
 
-		if dest != emptyValue {
+		if !noset {
 			dest.Index(i).Set(v.Elem())
 		}
 	}

--- a/bser/decode_test.go
+++ b/bser/decode_test.go
@@ -637,6 +637,20 @@ var decodeTests = map[string]decodeTest{
 			return dst, err
 		},
 	},
+	"raw_message_slice": {
+		// this is just an array of strings: ["ok", "there"]
+		encoded: []byte(
+			"\x00\x01\x05\x1c\x00\x00\x00\x01\x03\x01\x02\x03\x06Values\x00\x03\x02\x02\x03\x02ok\x02\x03\x05there",
+		),
+		expectedData: RawMessage([]byte(
+			"\x01\x03\x01\x02\x03\x06Values\x00\x03\x02\x02\x03\x02ok\x02\x03\x05there",
+		)),
+		doDecode: func(dec *Decoder) (interface{}, error) {
+			var v RawMessage
+			err := dec.Decode(&v)
+			return v, err
+		},
+	},
 }
 
 func TestDecode(t *testing.T) {


### PR DESCRIPTION
68bda102 added some logic to ensure that we never write past the len of
a slice or array when decoding. unfortunately, it didn't check if the
dest was valid - which is important for handling the rawmessage case.

subtly, i think this logic was wrong in the normal case, because we need
to continue reading from the byte stream even if we can't set the value,
so that further values that are decoded start from the correct position.

instead, treat this case (where i > len(dest)) as if we had an invalid
dest, which just keeps reading, but skips setting.