### PR TITLE
dont block untap on read or write

### DIFF
--- a/bser/tap.go
+++ b/bser/tap.go
@@ -81,16 +81,18 @@ func (t *Tap) Untap() {
 
 func (t *Tap) Read(b []byte) (int, error) {
 	t.mu.RLock()
-	defer t.mu.RUnlock()
+	r := t.r
+	t.mu.RUnlock()
 
-	return t.r.Read(b)
+	return r.Read(b)
 }
 
 func (t *Tap) Write(b []byte) (int, error) {
 	t.mu.RLock()
-	defer t.mu.RUnlock()
+	w := t.w
+	t.mu.RUnlock()
 
-	return t.w.Write(b)
+	return w.Write(b)
 }
 
 func (t *Tap) logWriter(fn func([]byte)) (io.Writer, func()) {

--- a/bser/tap_test.go
+++ b/bser/tap_test.go
@@ -1,0 +1,41 @@
+package bser
+
+import (
+	"testing"
+	"time"
+)
+
+// infiniteRW is a io.ReadWriter that never returns
+type infiniteRW struct{ readCh chan struct{} }
+
+func (r infiniteRW) Read(b []byte) (int, error) {
+	r.readCh <- struct{}{}
+	select {}
+}
+
+func (infiniteRW) Write(b []byte) (int, error) {
+	select {}
+}
+
+func TestUntapLongRead(t *testing.T) {
+	rw := infiniteRW{readCh: make(chan struct{})}
+
+	tap := NewTap(rw, nil, nil)
+
+	go tap.Read(nil)
+	// wait for read to have been called
+	<-rw.readCh
+
+	untapped := make(chan struct{})
+	go func() {
+		tap.Untap()
+		untapped <- struct{}{}
+	}()
+
+	select {
+	case <-untapped:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Untap did not return after 100 ms")
+	}
+
+}


### PR DESCRIPTION
the mutex protecting the reader and writer on the tap was blocking untap
from completing if there was a blocking read or write happening. fix
this by only protecting access to the field.